### PR TITLE
Added hide border option

### DIFF
--- a/__test__/__snapshots__/svgs.test.js.snap
+++ b/__test__/__snapshots__/svgs.test.js.snap
@@ -10,7 +10,7 @@ exports[`Test SVGs 1`] = `
         xmlns=\\"http://www.w3.org/2000/svg\\">
             <rect xmlns=\\"http://www.w3.org/2000/svg\\" data-testid=\\"card_bg\\" id=\\"cardBg\\" 
             x=\\"0\\" y=\\"0\\" rx=\\"2.5\\" height=\\"100%\\" stroke=\\"#E4E2E2\\" fill-opacity=\\"1\\" 
-            width=\\"100%\\" fill=\\"#undefined\\" stroke-opacity=\\"1\\" style=\\"stroke:#ffffff; stroke-width:1;\\"/>
+            width=\\"100%\\" fill=\\"#undefined\\" stroke-opacity=\\"1\\" style=\\"stroke:#undefined; stroke-width:1;\\"/>
         
             <style>
                 body {

--- a/__test__/fakeInputs.js
+++ b/__test__/fakeInputs.js
@@ -32,6 +32,15 @@ let fakeQueryString = [
     point: 'bd93f9',
     area: true,
   },
+  {
+    username: 'githubusername',
+    bg_color: '44475a',
+    color: 'f8f8f2',
+    line: 'ff79c6',
+    point: 'bd93f9',
+    area: true,
+    hide_border: true,
+  },
 ];
 
 let fakeQueryStringRes = [
@@ -39,6 +48,7 @@ let fakeQueryStringRes = [
     username: 'githubusername',
     colors: {
       bgColor: 'ffcfe9',
+      borderColor: 'ffffff',
       color: '9e4c98',
       lineColor: '9e4c98',
       pointColor: '403d3d',
@@ -49,6 +59,7 @@ let fakeQueryStringRes = [
     username: 'githubusername',
     colors: {
       bgColor: '44475a',
+      borderColor: 'ffffff',
       color: '9e4c98',
       lineColor: '9e4c98',
       pointColor: '403d3d',
@@ -59,6 +70,7 @@ let fakeQueryStringRes = [
     username: 'githubusername',
     colors: {
       bgColor: '44475a',
+      borderColor: 'ffffff',
       color: '000000',
       lineColor: '9e4c98',
       pointColor: '403d3d',
@@ -69,6 +81,7 @@ let fakeQueryStringRes = [
     username: 'githubusername',
     colors: {
       bgColor: '44475a',
+      borderColor: 'ffffff',
       color: '000000',
       lineColor: '9e4c98',
       pointColor: '403d3d',
@@ -79,6 +92,7 @@ let fakeQueryStringRes = [
     username: 'githubusername',
     colors: {
       bgColor: '44475a',
+      borderColor: 'ffffff',
       color: '000000',
       lineColor: '9e4c98',
       pointColor: '44475a',
@@ -89,6 +103,18 @@ let fakeQueryStringRes = [
     username: 'githubusername',
     colors: {
       bgColor: '44475a',
+      borderColor: 'ffffff',
+      color: 'f8f8f2',
+      lineColor: 'ff79c6',
+      pointColor: 'bd93f9',
+    },
+    area: true,
+  },
+  {
+    username: 'githubusername',
+    colors: {
+      bgColor: '44475a',
+      borderColor: '0000',
       color: 'f8f8f2',
       lineColor: 'ff79c6',
       pointColor: 'bd93f9',
@@ -321,48 +347,56 @@ const dummyWeeksData = [
 const themes = {
   dracula: {
     bgColor: '44475a',
+    borderColor: 'ffffff',
     color: 'f8f8f2',
     lineColor: 'ff79c6',
     pointColor: 'bd93f9',
   },
   gruvbox: {
     bgColor: '504945',
+    borderColor: 'ffffff',
     color: 'd4be98',
     lineColor: 'd8a657',
     pointColor: 'e78a4e',
   },
   github: {
     bgColor: '293036',
+    borderColor: 'ffffff',
     color: 'ffffff',
     lineColor: '9ecbff',
     pointColor: 'f97583',
   },
   rogue: {
     bgColor: '172030',
+    borderColor: 'ffffff',
     color: 'a3b09a',
     lineColor: 'b18bb1',
     pointColor: 'c6797e',
   },
   xcode: {
     bgColor: '202124',
+    borderColor: 'ffffff',
     color: 'fcfcfa',
     lineColor: 'c4e3ff',
     pointColor: 'ff8070',
   },
   redical: {
     bgColor: '141321',
+    borderColor: 'ffffff',
     color: 'a9fef7',
     lineColor: 'fe428e',
     pointColor: 'f8d847',
   },
   coral: {
     bgColor: '9a3838',
+    borderColor: 'ffffff',
     color: 'f9fae9',
     lineColor: 'f4e23d',
     pointColor: 'f4e7e7',
   },
   default: {
     bgColor: 'ffcfe9',
+    borderColor: 'ffffff',
     color: '9e4c98',
     lineColor: '9e4c98',
     pointColor: '403d3d',

--- a/__test__/fakeInputs.js
+++ b/__test__/fakeInputs.js
@@ -39,7 +39,7 @@ let fakeQueryString = [
     line: 'ff79c6',
     point: 'bd93f9',
     area: true,
-    hide_border: true,
+    hideBorder: true,
   },
 ];
 

--- a/interfaces/interface.ts
+++ b/interfaces/interface.ts
@@ -22,7 +22,7 @@ export interface queryOption {
 export interface ParsedQs {
   username?: string;
   bg_color?: string;
-  hide_border?: boolean;
+  hideBorder?: boolean;
   color?: string;
   line?: string;
   point?: string;

--- a/interfaces/interface.ts
+++ b/interfaces/interface.ts
@@ -7,6 +7,7 @@ export interface query {
 
 export interface colors {
   bgColor: string;
+  borderColor: string;
   color: string;
   lineColor: string;
   pointColor: string;
@@ -21,6 +22,7 @@ export interface queryOption {
 export interface ParsedQs {
   username?: string;
   bg_color?: string;
+  hide_border?: boolean;
   color?: string;
   line?: string;
   point?: string;

--- a/src/svgs.ts
+++ b/src/svgs.ts
@@ -13,7 +13,7 @@ export const graphSvg = (props: graphArgs) => `
             x="0" y="0" rx="2.5" height="100%" stroke="#E4E2E2" fill-opacity="1" 
             width="100%" fill="#${
               props.colors.bgColor
-            }" stroke-opacity="1" style="stroke:#ffffff; stroke-width:1;"/>
+            }" stroke-opacity="1" style="stroke:#${props.colors.borderColor}; stroke-width:1;"/>
         
             <style>
                 body {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ export const queryOptions = (queryString: ParsedQs): queryOption => {
     bgColor: queryString.bg_color
       ? queryString.bg_color
       : selectColors(theme).bgColor,
-    borderColor: queryString.hide_border === true
+    borderColor: String(queryString.hideBorder) === 'true'
       ? "0000" // transparent
       : selectColors(theme).borderColor,
     color: queryString.color

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,30 +14,30 @@ import { selectColors } from '../styles/themes';
 export const queryOptions = (queryString: ParsedQs): queryOption => {
   let area: boolean = false;
   let colors: colors;
+  let theme: string = queryString.theme || 'default';
 
   if (String(queryString.area) === 'true') {
     area = true;
   }
 
-  if (queryString.theme) {
-    colors = selectColors(queryString.theme as string);
-  } else {
-    //Custom options for user
-    colors = {
-      bgColor: queryString.bg_color
-        ? (queryString.bg_color as string)
-        : selectColors('default').bgColor,
-      color: queryString.color
-        ? (queryString.color as string)
-        : selectColors('default').color,
-      lineColor: queryString.line
-        ? (queryString.line as string)
-        : selectColors('default').lineColor,
-      pointColor: queryString.point
-        ? (queryString.point as string)
-        : selectColors('default').pointColor,
-    };
-  }
+  // Custom options for user
+  colors = {
+    bgColor: queryString.bg_color
+      ? queryString.bg_color
+      : selectColors(theme).bgColor,
+    borderColor: queryString.hide_border === true
+      ? "0000" // transparent
+      : selectColors(theme).borderColor,
+    color: queryString.color
+      ? queryString.color
+      : selectColors(theme).color,
+    lineColor: queryString.line
+      ? queryString.line
+      : selectColors(theme).lineColor,
+    pointColor: queryString.point
+      ? queryString.point
+      : selectColors(theme).pointColor,
+  };
 
   const options: queryOption = {
     username: String(queryString.username),

--- a/styles/themes.ts
+++ b/styles/themes.ts
@@ -5,6 +5,7 @@ export const selectColors = (queryString: string): colors => {
     case 'dracula':
       return {
         bgColor: '44475a',
+        borderColor: 'ffffff',
         color: 'f8f8f2',
         lineColor: 'ff79c6',
         pointColor: 'bd93f9',
@@ -12,6 +13,7 @@ export const selectColors = (queryString: string): colors => {
     case 'gruvbox':
       return {
         bgColor: '504945',
+        borderColor: 'ffffff',
         color: 'd4be98',
         lineColor: 'd8a657',
         pointColor: 'e78a4e',
@@ -19,6 +21,7 @@ export const selectColors = (queryString: string): colors => {
     case 'github':
       return {
         bgColor: '293036',
+        borderColor: 'ffffff',
         color: 'ffffff',
         lineColor: '9ecbff',
         pointColor: 'f97583',
@@ -26,6 +29,7 @@ export const selectColors = (queryString: string): colors => {
     case 'rogue':
       return {
         bgColor: '172030',
+        borderColor: 'ffffff',
         color: 'a3b09a',
         lineColor: 'b18bb1',
         pointColor: 'c6797e',
@@ -33,6 +37,7 @@ export const selectColors = (queryString: string): colors => {
     case 'xcode':
       return {
         bgColor: '202124',
+        borderColor: 'ffffff',
         color: 'fcfcfa',
         lineColor: 'c4e3ff',
         pointColor: 'ff8070',
@@ -40,6 +45,7 @@ export const selectColors = (queryString: string): colors => {
     case 'redical':
       return {
         bgColor: '141321',
+        borderColor: 'ffffff',
         color: 'a9fef7',
         lineColor: 'fe428e',
         pointColor: 'f8d847',
@@ -47,6 +53,7 @@ export const selectColors = (queryString: string): colors => {
     case 'coral':
       return {
         bgColor: '9a3838',
+        borderColor: 'ffffff',
         color: 'f9fae9',
         lineColor: 'f4e23d',
         pointColor: 'f4e7e7',
@@ -54,6 +61,7 @@ export const selectColors = (queryString: string): colors => {
     default:
       return {
         bgColor: 'ffcfe9',
+        borderColor: 'ffffff',
         color: '9e4c98',
         lineColor: '9e4c98',
         pointColor: '403d3d',


### PR DESCRIPTION
### All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions
1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Feature changes

* Added a `hide_border` query parameter which will set the stroke of the outer rectangle to `#0000` (transparent) when set to true.
* Using both the `theme` parameter and other options will allow the user to use a theme as their "base" and overwrite specific properties. This allows the user, for example, to pick a theme and decide to hide the border or change the background while keeping the other options from the theme.

### Screenshots

http://localhost:5100/graph?username=DenverCoder1&theme=redical

![image](https://user-images.githubusercontent.com/20955511/108378933-1c030280-720e-11eb-8089-05d93aba10ec.png)

http://localhost:5100/graph?username=DenverCoder1&theme=redical&hideBorder=true

![image](https://user-images.githubusercontent.com/20955511/108378902-16a5b800-720e-11eb-87ef-a83549768fef.png)
