### PR TITLE
adding area_color option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Customize the appearance of your Activity Graph however you want with URL params
 |    `color`     |            graph card's text color            |   hex code (without `#`)   |
 |     `line`     |              graph's line color               |   hex code (without `#`)   |
 |    `point`     |         color of points on line graph         |   hex code (without `#`)   |
+|  `area_color`  |      color of the area under the graph        |   hex code (without `#`)   |
 |     `area`     |          shows area under the graph           | boolean (default: `false`) |
 | `hide_border`  |   makes the border of the graph transparent   | boolean (default: `false`) |
 |  `hide_title`  |       sets the title to an empty string       | boolean (default: `false`) |

--- a/interfaces/interface.ts
+++ b/interfaces/interface.ts
@@ -6,6 +6,7 @@ export interface query {
 }
 
 export interface colors {
+  areaColor: string;
   bgColor: string;
   borderColor: string;
   color: string;
@@ -27,6 +28,7 @@ export interface ParsedQs {
   custom_title?: string;
   bg_color?: string;
   hide_border?: boolean;
+  area_color?: string;
   color?: string;
   line?: string;
   point?: string;

--- a/src/svgs.ts
+++ b/src/svgs.ts
@@ -9,12 +9,12 @@ export const graphSvg = (props: graphArgs) => `
         viewBox="0 0 ${props.width} ${props.height}"
         fill="none"
         xmlns="http://www.w3.org/2000/svg">
-            <rect xmlns="http://www.w3.org/2000/svg" data-testid="card_bg" id="cardBg" 
-            x="0" y="0" rx="2.5" height="100%" stroke="#E4E2E2" fill-opacity="1" 
+            <rect xmlns="http://www.w3.org/2000/svg" data-testid="card_bg" id="cardBg"
+            x="0" y="0" rx="2.5" height="100%" stroke="#E4E2E2" fill-opacity="1"
             width="100%" fill="#${
               props.colors.bgColor
             }" stroke-opacity="1" style="stroke:#${props.colors.borderColor}; stroke-width:1;"/>
-        
+
             <style>
                 body {
                     font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
@@ -23,7 +23,7 @@ export const graphSvg = (props: graphArgs) => `
                     font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
                     text-align: center;
                     color: #${props.colors.color};
-                    margin-top: 20px; 
+                    margin-top: 20px;
                 }
                 svg {
                     font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
@@ -31,7 +31,8 @@ export const graphSvg = (props: graphArgs) => `
                 ${graphStyle(
                   props.colors.color,
                   props.colors.lineColor,
-                  props.colors.pointColor
+                  props.colors.pointColor,
+                  props.colors.areaColor
                 )}
                 ${pointAnimation()}
                 ${lineAnimation()}
@@ -58,8 +59,8 @@ export const invalidUserSvg = (data: string) => `
                     font: 600 14px 'Segoe UI', Ubuntu, Sans-Serif;
                 }
         </style>
-        <rect xmlns="http://www.w3.org/2000/svg" data-testid="card_bg" id="cardBg" x="0.5" 
-        y="0.5" rx="4.5" height="100%" stroke="#E4E2E2" fill-opacity="1" width="100%" 
+        <rect xmlns="http://www.w3.org/2000/svg" data-testid="card_bg" id="cardBg" x="0.5"
+        y="0.5" rx="4.5" height="100%" stroke="#E4E2E2" fill-opacity="1" width="100%"
         fill="#44475a" stroke-opacity="1"/>
         <text x="20" y="100" fill="#bd93f9">${data}</text>
     </svg>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,6 +22,9 @@ export const queryOptions = (queryString: ParsedQs): queryOption => {
 
   // Custom options for user
   colors = {
+    areaColor: queryString.area_color
+      ? queryString.area_color
+      : selectColors(theme).areaColor,
     bgColor: queryString.bg_color
       ? queryString.bg_color
       : selectColors(theme).bgColor,

--- a/styles/graphStyle.ts
+++ b/styles/graphStyle.ts
@@ -1,4 +1,4 @@
-export const graphStyle = (color: string, line: string, point: string) =>
+export const graphStyle = (color: string, line: string, point: string, area: string) =>
   `
     .ct-label {
       fill: #${color};
@@ -77,7 +77,7 @@ export const graphStyle = (color: string, line: string, point: string) =>
     .ct-grid {
       stroke: #${color};
       stroke-width: 1px;
-      stroke-opacity: 0.3;  
+      stroke-opacity: 0.3;
       stroke-dasharray: 2px;
     }
 
@@ -95,7 +95,7 @@ export const graphStyle = (color: string, line: string, point: string) =>
       stroke: #${line};
       animation: dash 5s ease-in-out forwards;
     }
-    
+
     .ct-area {
       stroke: none;
       fill-opacity: 0.1;
@@ -103,11 +103,11 @@ export const graphStyle = (color: string, line: string, point: string) =>
 
     .ct-series-a .ct-area,
     .ct-series-a .ct-slice-pie {
-      fill: skyblue;
+      fill: #${area};
     }
 
     .ct-label .ct-horizontal {
       transform: rotate(-90deg)
     }
-    
+
     `;

--- a/styles/themes.ts
+++ b/styles/themes.ts
@@ -4,6 +4,7 @@ export const selectColors = (queryString: string): colors => {
   switch (queryString) {
     case 'dracula':
       return {
+        areaColor: '87ceeb',
         bgColor: '44475a',
         borderColor: 'ffffff',
         color: 'f8f8f2',
@@ -12,6 +13,7 @@ export const selectColors = (queryString: string): colors => {
       };
     case 'gruvbox':
       return {
+        areaColor: '87ceeb',
         bgColor: '504945',
         borderColor: 'ffffff',
         color: 'd4be98',
@@ -20,6 +22,7 @@ export const selectColors = (queryString: string): colors => {
       };
     case 'github':
       return {
+        areaColor: '87ceeb',
         bgColor: '293036',
         borderColor: 'ffffff',
         color: 'ffffff',
@@ -28,6 +31,7 @@ export const selectColors = (queryString: string): colors => {
       };
     case 'rogue':
       return {
+        areaColor: '87ceeb',
         bgColor: '172030',
         borderColor: 'ffffff',
         color: 'a3b09a',
@@ -36,6 +40,7 @@ export const selectColors = (queryString: string): colors => {
       };
     case 'xcode':
       return {
+        areaColor: '87ceeb',
         bgColor: '202124',
         borderColor: 'ffffff',
         color: 'fcfcfa',
@@ -44,6 +49,7 @@ export const selectColors = (queryString: string): colors => {
       };
     case 'redical':
       return {
+        areaColor: '87ceeb',
         bgColor: '141321',
         borderColor: 'ffffff',
         color: 'a9fef7',
@@ -52,6 +58,7 @@ export const selectColors = (queryString: string): colors => {
       };
     case 'coral':
       return {
+        areaColor: '87ceeb',
         bgColor: '9a3838',
         borderColor: 'ffffff',
         color: 'f9fae9',
@@ -60,6 +67,7 @@ export const selectColors = (queryString: string): colors => {
       };
     case 'react-dark':
       return {
+        areaColor: '87ceeb',
         bgColor: '0d1117',
         borderColor: 'ffffff',
         color: '5bcdec',
@@ -68,6 +76,7 @@ export const selectColors = (queryString: string): colors => {
       };
     case 'nord':
       return {
+        areaColor: '87ceeb',
         bgColor: '2e3440',
         borderColor: 'ffffff',
         color: '88c0d0',
@@ -76,6 +85,7 @@ export const selectColors = (queryString: string): colors => {
       };
     case 'lucent':
       return {
+        areaColor: '87ceeb',
         bgColor: 'cccccc',
         borderColor: '000000',
         color: '000000',
@@ -84,6 +94,7 @@ export const selectColors = (queryString: string): colors => {
     };
     default:
       return {
+        areaColor: '87ceeb',
         bgColor: 'ffcfe9',
         borderColor: 'ffffff',
         color: '9e4c98',


### PR DESCRIPTION
Okay so i've added the `area_color` option to the query string and updated the main README.

In order to implement it I had to set a default area color for each theme. I just used `#87ceeb` which is the hex code for skyblue (the existing default)... you may want to update the themes individually as a separate issue.

My text editor also automatically cleaned up some trailing spaces.