### PR TITLE
Apply some labels automatically when templates are used

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug Report
 about: Create a report to help us improve
-title: BUG
-labels: ''
+title: 'BUG: '
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: NEW FEATURE REQUEST
-labels: ''
+title: 'NEW FEATURE: '
+labels: 'enhancement'
 assignees: ''
 
 ---


### PR DESCRIPTION
### All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

Since all issues created with the bug template are bugs and all feature requests are enhancements, it may make sense to automatically add the `bug` label when bugs are submitted and automatically add `enhancement` when feature requests are submitted.

I also added `:` in the default titles to make it appear more like a prompt where users should add the actual title.