### PR TITLE
Border radius feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Customize the appearance of your Activity Graph however you want with URL params
 |  `hide_title`  |       sets the title to an empty string       | boolean (default: `false`) |
 | `custom_title` |          set the title to any string          |           string           |
 |    `theme`     | name of [available themes](#available-themes) |           string           |
+|   `radius`     |            border radius of graph             |  number (0-16 inclusive)   |
 
 ⚠ **For `custom_title` please make sure you are use %20 for spaces**
 

--- a/__test__/__snapshots__/svgs.test.ts.snap
+++ b/__test__/__snapshots__/svgs.test.ts.snap
@@ -24,6 +24,7 @@ exports[`SVG Testing Test SVGs 1`] = `
                 }
                 svg {
                     font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
+                    border-radius: 0px;
                 }
                 
     .ct-label {
@@ -213,6 +214,7 @@ exports[`SVG Testing chart SVGs 1`] = `
                 }
                 svg {
                     font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
+                    border-radius: 8px;
                 }
                 
     .ct-label {

--- a/__test__/fakeInputs.ts
+++ b/__test__/fakeInputs.ts
@@ -3,17 +3,20 @@ import { GraphArgs } from '../src/interfaces/interface';
 export let fakeQueryString = [
     {
         username: 'githubusername',
+        radius: 8,
         hide_title: false,
         custom_title: undefined,
     },
     {
         username: 'githubusername',
+        radius: -10,
         bg_color: '44475a',
         hide_title: false,
         custom_title: undefined,
     },
     {
         username: 'githubusername',
+        radius: 35,
         bg_color: '44475a',
         color: '000000',
         hide_title: false,
@@ -83,6 +86,7 @@ export let fakeQueryString = [
 export let fakeQueryStringRes = [
     {
         username: 'githubusername',
+        radius: 8,
         colors: {
             areaColor: '9e4c98',
             bgColor: 'ffcfe9',
@@ -96,6 +100,7 @@ export let fakeQueryStringRes = [
     },
     {
         username: 'githubusername',
+        radius: 0,
         colors: {
             areaColor: '9e4c98',
             bgColor: '44475a',
@@ -109,6 +114,7 @@ export let fakeQueryStringRes = [
     },
     {
         username: 'githubusername',
+        radius: 16,
         colors: {
             areaColor: '9e4c98',
             bgColor: '44475a',
@@ -122,6 +128,7 @@ export let fakeQueryStringRes = [
     },
     {
         username: 'githubusername',
+        radius: 0,
         colors: {
             areaColor: '9e4c98',
             bgColor: '44475a',
@@ -135,6 +142,7 @@ export let fakeQueryStringRes = [
     },
     {
         username: 'githubusername',
+        radius: 0,
         colors: {
             areaColor: '9e4c98',
             bgColor: '44475a',
@@ -148,6 +156,7 @@ export let fakeQueryStringRes = [
     },
     {
         username: 'githubusername',
+        radius: 0,
         colors: {
             areaColor: '9e4c98',
             bgColor: '44475a',
@@ -161,6 +170,7 @@ export let fakeQueryStringRes = [
     },
     {
         username: 'githubusername',
+        radius: 0,
         colors: {
             areaColor: '9e4c98',
             bgColor: '44475a',
@@ -174,6 +184,7 @@ export let fakeQueryStringRes = [
     },
     {
         username: 'githubusername',
+        radius: 0,
         colors: {
             areaColor: '9e4c98',
             bgColor: '44475a',
@@ -187,6 +198,7 @@ export let fakeQueryStringRes = [
     },
     {
         username: 'githubusername',
+        radius: 0,
         colors: {
             areaColor: '9e4c98',
             bgColor: '44475a',
@@ -204,6 +216,7 @@ export let fakeQueryStringRes = [
 export let fakeGraphArgs: GraphArgs = {
     height: 10,
     width: 20,
+    radius: 0,
     colors: {
         areaColor: '87ceeb',
         bgColor: '44475a',

--- a/__test__/svgs.test.ts
+++ b/__test__/svgs.test.ts
@@ -20,6 +20,7 @@ describe('SVG Testing', () => {
             await new Card(
                 420,
                 1200,
+                fakeQueryStringRes[0].radius,
                 fakeQueryStringRes[0].colors,
                 "xyz's Contribution Graph",
                 fakeQueryStringRes[0].area

--- a/src/GraphCards.ts
+++ b/src/GraphCards.ts
@@ -6,6 +6,7 @@ export class Card {
     constructor(
         private readonly height: number,
         private readonly width: number,
+        private readonly radius: number,
         private readonly colors: Colors,
         private readonly title = '',
         private readonly area = false
@@ -72,6 +73,7 @@ export class Card {
             width: this.width,
             colors: this.colors,
             title: this.title,
+            radius: this.radius,
             line,
         };
 

--- a/src/interfaces/interface.ts
+++ b/src/interfaces/interface.ts
@@ -20,6 +20,7 @@ export class QueryOption {
     custom_title?: string;
     colors: Colors;
     area: boolean;
+    radius: number;
 }
 
 export class ParsedQs {
@@ -34,6 +35,7 @@ export class ParsedQs {
     point?: string;
     theme?: string;
     area?: boolean;
+    radius?: number;
 }
 
 export class GraphArgs {
@@ -41,6 +43,7 @@ export class GraphArgs {
     width: number;
     colors: Colors;
     title: string;
+    radius: number;
     line: Promise<string>;
 }
 

--- a/src/svgs.ts
+++ b/src/svgs.ts
@@ -27,6 +27,7 @@ export const graphSvg = (props: GraphArgs) => `
                 }
                 svg {
                     font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
+                    border-radius: ${props.radius}px;
                 }
                 ${graphStyle(
                     props.colors.color,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,6 +45,7 @@ export class Utilities {
         const options: QueryOption = {
             username: this.username,
             hide_title: String(this.queryString.hide_title) === 'true',
+            radius:  this.queryString.radius ? Math.min(Math.max(this.queryString.radius, 0), 16) : 0, // Border radius in range [0, 16]
             colors: colors,
             area: area,
         };
@@ -70,7 +71,7 @@ export class Utilities {
                 }
             }
 
-            const graph = new Card(420, 1200, options.colors, title, options.area);
+            const graph = new Card(420, 1200, options.radius, options.colors, title, options.area);
 
             const getChart = await graph.buildGraph(fetchCalendarData.contributions);
 


### PR DESCRIPTION
## New Feature Submissions

- [x] Added option to adjust the radius of final graph using the query string `&radius=<value>`. The value will be in range 0-16 inclusive. Value less than 0 or greater than 16 will be round to 0 or 16 respectively. Default is 0
- [x] Add tests for this feature
- [x] Update svg test snapshots for border-radius

![screenshot](https://user-images.githubusercontent.com/68581632/167151657-9b4de67e-7ebe-47a9-8fa2-1178e4410558.png).
![Screenshot 2022-05-06 200749](https://user-images.githubusercontent.com/68581632/167155096-b5756386-606f-449c-a726-bf22cc7b12d4.png)

## Changes to Core Features
No changes in the core feature