### PR TITLE
Fix "attention" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Just paste the following URL in your profile readme and you are good to go.
 [![Ashutosh's github activity graph](https://github-readme-activity-graph.vercel.app/graph?username=Ashutosh00710)](https://github.com/ashutosh00710/github-readme-activity-graph)
 ```
 
-### [Attention ⚠](#Deploy-on-your-own-heroku-instance)
+### [Attention ⚠](#deploy-on-your-own-replit-instance)
 
 ## Use themes
 


### PR DESCRIPTION
After dropping the section about deploying to Heroku, there is left an unchanged "attention" link in "How to use" section.

### All Submissions

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
