### PR TITLE
feat(themes): add "radical" as an alias for "redical"

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -3,7 +3,6 @@
 |          Name          |                              Preview                               |
 | :--------------------: | :----------------------------------------------------------------: |
 |      **radical**       |      <img src="./asset/redical.svg" height=250 alt="graph"/>       |
-|      **redical**       |      <img src="./asset/redical.svg" height=250 alt="graph"/>       |
 |       **coral**        |       <img src="./asset/coral.svg" height=250 alt="graph"/>        |
 |        **nord**        |        <img src="./asset/nord.svg" height=250 alt="graph"/>        |
 |       **lucent**       |       <img src="./asset/lucent.svg" height=250 alt="graph"/>       |

--- a/THEMES.md
+++ b/THEMES.md
@@ -2,6 +2,7 @@
 
 |          Name          |                              Preview                               |
 | :--------------------: | :----------------------------------------------------------------: |
+|      **radical**       |      <img src="./asset/redical.svg" height=250 alt="graph"/>       |
 |      **redical**       |      <img src="./asset/redical.svg" height=250 alt="graph"/>       |
 |       **coral**        |       <img src="./asset/coral.svg" height=250 alt="graph"/>        |
 |        **nord**        |        <img src="./asset/nord.svg" height=250 alt="graph"/>        |

--- a/__test__/themes.test.ts
+++ b/__test__/themes.test.ts
@@ -2,12 +2,13 @@ import { selectColors } from '../src/styles/themes';
 import { themes } from './fakeInputs';
 
 test('Theme testing', () => {
-    expect.assertions(22);
+    expect.assertions(23);
     expect(selectColors('dracula')).toEqual(themes['dracula']);
     expect(selectColors('gruvbox')).toEqual(themes['gruvbox']);
     expect(selectColors('github')).toEqual(themes['github']);
     expect(selectColors('rogue')).toEqual(themes['rogue']);
     expect(selectColors('redical')).toEqual(themes['redical']);
+    expect(selectColors('radical')).toEqual(themes['redical']);
     expect(selectColors('xcode')).toEqual(themes['xcode']);
     expect(selectColors('coral')).toEqual(themes['coral']);
     expect(selectColors('react-dark')).toEqual(themes['reactDark']);

--- a/index.html
+++ b/index.html
@@ -117,7 +117,6 @@
                             <option value="gotham">Gotham</option>
                             <option value="rogue">Rogue</option>
                             <option value="xcode">Xcode</option>
-                            <option value="redical">Redical</option>
                             <option value="radical">Radical</option>
                             <option value="coral">Coral</option>
                             <option value="react">React</option>

--- a/index.html
+++ b/index.html
@@ -118,6 +118,7 @@
                             <option value="rogue">Rogue</option>
                             <option value="xcode">Xcode</option>
                             <option value="redical">Redical</option>
+                            <option value="radical">Radical</option>
                             <option value="coral">Coral</option>
                             <option value="react">React</option>
                             <option value="react-dark">React Dark</option>

--- a/script.js
+++ b/script.js
@@ -29,6 +29,7 @@ const themes = {
     rogue: { bgColor: '#172030', line: '#b18bb1', point: '#c6797e', color: '#a3b09a' },
     xcode: { bgColor: '#202124', line: '#c4e3ff', point: '#ff8070', color: '#fcfcfa' },
     redical: { bgColor: '#141321', line: '#fe428e', point: '#f8d847', color: '#a9fef7' },
+    radical: { bgColor: '#141321', line: '#fe428e', point: '#f8d847', color: '#a9fef7' },
     coral: { bgColor: '#9a3838', line: '#f4e23d', point: '#f4e7e7', color: '#f9fae9' },
     react: { bgColor: '#282c34', line: '#61dafb', point: '#61dafb', color: '#ffffff' },
     'react-dark': { bgColor: '#0d1117', line: '#5bcdec', point: '#ffffff', color: '#5bcdec' },

--- a/script.js
+++ b/script.js
@@ -28,7 +28,6 @@ const themes = {
     gotham: { bgColor: '#0c1014', line: '#599cab', point: '#99d1ce', color: '#2aa889' },
     rogue: { bgColor: '#172030', line: '#b18bb1', point: '#c6797e', color: '#a3b09a' },
     xcode: { bgColor: '#202124', line: '#c4e3ff', point: '#ff8070', color: '#fcfcfa' },
-    redical: { bgColor: '#141321', line: '#fe428e', point: '#f8d847', color: '#a9fef7' },
     radical: { bgColor: '#141321', line: '#fe428e', point: '#f8d847', color: '#a9fef7' },
     coral: { bgColor: '#9a3838', line: '#f4e23d', point: '#f4e7e7', color: '#f9fae9' },
     react: { bgColor: '#282c34', line: '#61dafb', point: '#61dafb', color: '#ffffff' },

--- a/src/styles/themes.ts
+++ b/src/styles/themes.ts
@@ -102,7 +102,11 @@ export const selectColors = (queryString: string): Colors => {
                 lineColor: 'c4e3ff',
                 pointColor: 'ff8070',
             };
+        // "redical" was originally added as a typo of "radical" (see #236).
+        // Both names are accepted to avoid breaking users who already
+        // configured "redical"; "radical" is the canonical name going forward.
         case 'redical':
+        case 'radical':
             return {
                 areaColor: 'fe428e',
                 bgColor: '141321',


### PR DESCRIPTION
## Summary

This PR adds `radical` as an alias for the existing `redical` theme. Both names map to the same colors, so no existing user is broken.

## Background

The `redical` theme appears to have been introduced as a misspelling of `radical` (its color palette matches the `radical` theme of `anuraghazra/github-readme-stats` exactly: `#141321` / `#fe428e` / `#a9fef7` / `#f8d847`).

A previous attempt to rename it (#236) was closed because renaming would break users who already configured `theme=redical`. This PR takes a different approach: keep `redical` working forever, while letting new users discover and use the canonical name `radical`.

## Changes

- `src/styles/themes.ts`: add a `case 'radical':` fall-through next to `redical`, with a comment explaining the history
- `__test__/themes.test.ts`: add an assertion that `radical` returns the same colors as `redical`
- `THEMES.md`: list `radical` in the theme table (sharing the `redical.svg` preview since the colors are identical)
- `index.html` / `script.js`: expose `radical` in the web preview UI

## Test plan

- [x] `npx jest __test__/themes.test.ts` — passes (1 test, 23 assertions)
- [x] No behavioral change for existing `theme=redical` users
- [ ] Reviewer to confirm the wording in `themes.ts` reflects the intended position

---

Thanks for maintaining this project — I use it on my own profile README ([github.com/mado-m/mado-m](https://github.com/mado-m/mado-m)) and it has been great. Hopefully this small alias makes it a bit easier for newcomers without disrupting anyone.