### PR TITLE
docs(README): update deployment notice — cyclic.app is dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A dynamically generated activity graph to show your GitHub activities of last 31
 
 ### ⚠️ NOTICE: DEPLOYMENT MOVED ⚠️
 
-The deployment of this project is moved from `https://activity-graph.herokuapp.com` domain to `https://github-readme-activity-graph.cyclic.app`. In case `https://github-readme-activity-graph.cyclic.app` doesn't work try with `https://github-readme-activity-graph.vercel.app` for more details, refer [this](https://github.com/Ashutosh00710/github-readme-activity-graph/issues/197#issuecomment-1560633754)
+The canonical deployment is now `https://github-readme-activity-graph.vercel.app`. Previous deployments at `https://activity-graph.herokuapp.com` (Heroku free tier discontinued) and `https://github-readme-activity-graph.cyclic.app` (Cyclic.sh shut down in early 2025) are no longer reachable. For background see [issue #197](https://github.com/Ashutosh00710/github-readme-activity-graph/issues/197#issuecomment-1560633754).
 
 Please refer to the updated link [here](#how-to-use)
 


### PR DESCRIPTION
## Issue

The 'Deployment Moved' notice near the top of the README directs users to:

> \`https://github-readme-activity-graph.cyclic.app\`

as the canonical deployment, with the Vercel URL listed only as a fallback. But Cyclic.sh shut down in early 2025 and that domain no longer resolves. New users who follow the notice literally hit a DNS failure before they get to the working Vercel deployment further down the doc.

## Fix

Reword the notice so:
- \`github-readme-activity-graph.vercel.app\` is the canonical deployment.
- The old Heroku and Cyclic URLs are marked as historical.
- The link to issue #197 is preserved for context.

One-paragraph README edit, no other changes.

## Verification

- The current Vercel deployment at \`github-readme-activity-graph.vercel.app\` is up and serving the activity graph used by many profile READMEs.
- Cyclic.sh wind-down was announced and the platform shut down end of 2024 / early 2025.